### PR TITLE
Lock the haros version

### DIFF
--- a/extractor-interface/Dockerfile
+++ b/extractor-interface/Dockerfile
@@ -16,7 +16,7 @@ ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/lib/llvm-3.8/lib
 RUN pip install --upgrade pip
 RUN pip install -Iv clang==3.8
 RUN pip install -e git+https://github.com/timtadh/pyflwor.git#egg=pyflwor
-RUN pip install haros
+RUN pip install haros==3.1.0
 RUN pip install bonsai-code
 
 RUN apt-get update && apt-get install -y ros-kinetic-desktop


### PR DESCRIPTION
I had some issues running some of the examples after I built the docker image from scratch (e. g. the cob_sick_s300 example worked, but ros_tutorials/turtlesim/turtlesim_node didn't anymore)

This was the error:

```
Traceback (most recent call last):

  File "/root/extractor-interface/scripts/ros_model_extractor.py", line 364, in <module>

    main()

  File "/root/extractor-interface/scripts/ros_model_extractor.py", line 359, in main

    if extractor.launch():

  File "/root/extractor-interface/scripts/ros_model_extractor.py", line 51, in launch

    self.extract_node(self.args.name, self.args.name, self.args.package_name, None, ws, None)

  File "/root/extractor-interface/scripts/ros_model_extractor.py", line 115, in extract_node

    self.extract_primitives(node, parser.global_scope, analysis, rosmodel, roscomponent, pkg_name, node_name, node_name)

  File "/root/extractor-interface/scripts/ros_model_extractor.py", line 128, in extract_primitives

    msg_type = analysis._extract_message_type(call)

  File "/usr/local/lib/python2.7/dist-packages/haros/extractor.py", line 1069, in _extract_message_type

    assert re.match(r"\w+::\w+$", template)

AssertionError

```
I think it was because of some incompatibility with a newer haros version and specifying the version fixed it for me.

